### PR TITLE
[codex] Takumi Guardを導入

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://npm.flatt.tech/
+//npm.flatt.tech/:_authToken=${TAKUMI_GUARD_NPM_TOKEN}

--- a/README.md
+++ b/README.md
@@ -27,4 +27,13 @@ https://nextjs-blog-app-gamma-one.vercel.app/
 3. プロジェクトソースとしてこのリポジトリを選択します。
 4. 必要に応じて環境変数を設定し、デプロイします。
 
+### Takumi Guard
+
+依存パッケージの取得には Takumi Guard を利用します。
+Vercel などのデプロイ環境では、以下の環境変数を設定してください。
+
+```bash
+TAKUMI_GUARD_NPM_TOKEN=your-takumi-guard-token
+```
+
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fnext.js%2Ftree%2Fcanary%2Fexamples%2Fhello-world)


### PR DESCRIPTION
## 概要

Takumi Guard 経由で依存パッケージを取得する設定を追加しました。

## 変更内容

- `.npmrc` を追加し、npm registry を Takumi Guard に向けるように設定
- `TAKUMI_GUARD_NPM_TOKEN` を環境変数として参照
- README にデプロイ環境で必要な環境変数を追記

## 確認

- ローカルに `TAKUMI_GUARD_NPM_TOKEN` が設定されていないため、依存取得とビルドは未実行です。