### PR TITLE
[codex] 記事詳細の背景色を白に統一

### DIFF
--- a/src/app/(main)/(user)/[userId]/posts/[postId]/page.tsx
+++ b/src/app/(main)/(user)/[userId]/posts/[postId]/page.tsx
@@ -41,7 +41,7 @@ const ArticleView = async ({ userId, postId }: ArticleViewProps) => {
 
 	return (
 		<main className="flex-auto w-full">
-			<article className="bg-slate-50">
+			<article className="bg-white">
 				{/* Profile */}
 				<aside className="sticky top-16 bg-white/90 border-b border-slate-200 z-10 backdrop-blur">
 					<div className="flex items-center justify-between max-w-3xl px-4 mx-auto sm:px-6">


### PR DESCRIPTION
## 概要
- 記事詳細ページの外側背景を白に変更しました
- 本文カラムと左右の背景色が急に切り替わって見える違和感を解消しました

## 確認したこと
- `pnpm run lint` 成功